### PR TITLE
ci: update action versions to use node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     env:
       NODE_ENV: test
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: "npm"

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -17,8 +17,8 @@ jobs:
     env:
       NODE_ENV: test
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: "npm"


### PR DESCRIPTION
Node 16 is EOL, updating action versions to use Node 20 runtime

actions/checkout upgrade notes:
* v2-> v3: https://github.com/actions/checkout/releases/tag/v3.0.0
* v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0

actions/setup-node upgrade notes:
* v2 -> v3: https://github.com/actions/setup-node/releases/tag/v3.0.0
* v3 -> v4: https://github.com/actions/setup-node/releases/tag/v4.0.0